### PR TITLE
DefinitionManager Attribute

### DIFF
--- a/src/XrmFramework.DefinitionManager/Attributes/CoreProjectAttribute.cs
+++ b/src/XrmFramework.DefinitionManager/Attributes/CoreProjectAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace DefinitionManager;
+
+[AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = false)]
+public sealed class CoreProjectAttribute : Attribute
+{
+	public string RootFolder { get; }
+	public string Name { get; }
+	public CoreProjectAttribute(string rootFolder, string name)
+	{
+		RootFolder = rootFolder;
+		Name = name;
+	}
+}

--- a/src/XrmFramework.DefinitionManager/MainForm.cs
+++ b/src/XrmFramework.DefinitionManager/MainForm.cs
@@ -24,14 +24,15 @@ namespace XrmFramework.DefinitionManager
         private readonly List<OptionSetEnum> _enums = new();
 
         private readonly Type _iServiceType;
-
-        public string CoreProjectName { get; }
-
-        public MainForm(Type iServiceType, string coreProjectName)
+        private readonly CoreProjectAttribute _coreProject;
+        
+        public MainForm(Type iServiceType, string coreProjectName = "")
         {
             _iServiceType = iServiceType;
-            CoreProjectName = coreProjectName;
             CustomProvider.Instance = this;
+
+            _coreProject = Assembly.GetCallingAssembly().GetCustomAttribute<CoreProjectAttribute>();
+            
             InitializeComponent();
 
             DataAccessManager.Instance.StepChanged += StepChangedHandler;
@@ -360,7 +361,7 @@ namespace XrmFramework.DefinitionManager
                 sb.AppendLine("using System.Diagnostics.CodeAnalysis;");
                 sb.AppendLine("using XrmFramework;");
                 sb.AppendLine();
-                sb.AppendLine($"namespace {CoreProjectName}");
+                sb.AppendLine($"namespace {_coreProject.Name}");
                 sb.AppendLine("{");
 
                 using (sb.Indent())
@@ -590,9 +591,9 @@ namespace XrmFramework.DefinitionManager
 
                 sb.AppendLine("}");
 
-                var fileInfo = new FileInfo($"../../../../../{CoreProjectName}/Definitions/{item.Name}.cs");
+                var fileInfo = new FileInfo($"{_coreProject.RootFolder}/Definitions/{item.Name}.cs");
 
-                var definitionFolder = new DirectoryInfo($"../../../../../{CoreProjectName}/Definitions");
+                var definitionFolder = new DirectoryInfo($"{_coreProject.RootFolder}/Definitions");
                 if (definitionFolder.Exists == false)
                 {
                     definitionFolder.Create();
@@ -600,7 +601,7 @@ namespace XrmFramework.DefinitionManager
 
                 File.WriteAllText(fileInfo.FullName, sb.ToString());
 
-                var fileInfo2 = new FileInfo($"../../../../../{CoreProjectName}/Definitions/{item.Name.Replace("Definition", string.Empty)}.table");
+                var fileInfo2 = new FileInfo($"{_coreProject.RootFolder}/Definitions/{item.Name.Replace("Definition", string.Empty)}.table");
 
                 File.WriteAllText(fileInfo2.FullName, entityTxt);
             }
@@ -622,7 +623,7 @@ namespace XrmFramework.DefinitionManager
                 DefaultValueHandling = DefaultValueHandling.Ignore
             });
 
-            var fileInfoOptionSets = new FileInfo($"../../../../../{CoreProjectName}/Definitions/{globalOptionSets.Name}.table");
+            var fileInfoOptionSets = new FileInfo($"{_coreProject.RootFolder}/Definitions/{globalOptionSets.Name}.table");
 
             File.WriteAllText(fileInfoOptionSets.FullName, optionSetsTxt);
 
@@ -630,7 +631,7 @@ namespace XrmFramework.DefinitionManager
             fc.AppendLine("using System.ComponentModel;");
             fc.AppendLine("using XrmFramework;");
             fc.AppendLine();
-            fc.AppendLine($"namespace {CoreProjectName}");
+            fc.AppendLine($"namespace {_coreProject.Name}");
             fc.AppendLine("{");
 
             using (fc.Indent())
@@ -684,7 +685,7 @@ namespace XrmFramework.DefinitionManager
             }
 
             fc.AppendLine("}");
-            File.WriteAllText($"../../../../../{CoreProjectName}/Definitions/OptionSetDefinitions.cs", fc.ToString());
+            File.WriteAllText($"{_coreProject.RootFolder}/Definitions/OptionSetDefinitions.cs", fc.ToString());
 
             MessageBox.Show(@"Definition files generation succeeded");
         }

--- a/src/XrmFramework.DefinitionManager/build/net462/XrmFramework.DefinitionManager.props
+++ b/src/XrmFramework.DefinitionManager/build/net462/XrmFramework.DefinitionManager.props
@@ -7,11 +7,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)/$(XrmFrameworkCoreProjectName)/$(XrmFrameworkCoreProjectName).csproj" />
+    <ProjectReference Include="$(RootFolder)/$(XrmFrameworkCoreProjectName)/$(XrmFrameworkCoreProjectName).csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="$(SolutionDir)/$(XrmFrameworkCoreProjectName)/**/*.table" >
+    <Content Include="$(RootFolder)/$(XrmFrameworkCoreProjectName)/**/*.table" >
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/XrmFramework.DefinitionManager/build/net462/XrmFramework.DefinitionManager.props
+++ b/src/XrmFramework.DefinitionManager/build/net462/XrmFramework.DefinitionManager.props
@@ -15,5 +15,11 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
+  
+  <ItemGroup>
+    <AssemblyAttribute Include="DefinitionManager.CoreProjectAttribute">
+      <_Parameter1>$(RootFolder)/$(XrmFrameworkCoreProjectName)</_Parameter1>
+      <_Parameter2>$(XrmFrameworkCoreProjectName)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/XrmFramework.RemoteDebugger.Client/build/net462/XrmFramework.RemoteDebugger.Client.props
+++ b/src/XrmFramework.RemoteDebugger.Client/build/net462/XrmFramework.RemoteDebugger.Client.props
@@ -2,15 +2,15 @@
 
   
   <ItemGroup>
-    <None Include="$(SolutionDir)\Config\App.config" Condition="">
+    <None Include="$(RootFolder)\Config\App.config" Condition="">
       <Link>App.config</Link>
       <SubType>Designer</SubType>
     </None>
-    <None Include="$(SolutionDir)\Config\connectionStrings.config">
+    <None Include="$(RootFolder)\Config\connectionStrings.config">
       <Link>connectionStrings.config</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <Content Include="$(SolutionDir)\Config\xrmFramework.config">
+    <Content Include="$(RootFolder)\Config\xrmFramework.config">
       <Link>xrmFramework.config</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
Using an Assembly Attribute to inject the location of the core project so DefinitionManager doesn't have to assume it.

It uses Properties that are already well known in a typical xrmframework solution