### PR TITLE
CrmSettingsFactory

### DIFF
--- a/src/XrmFramework/Service/CrmSettingsFactory.cs
+++ b/src/XrmFramework/Service/CrmSettingsFactory.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Windows;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Newtonsoft.Json;
+using XrmFramework.BindingModel;
+using XrmFramework.Definitions;
+using XrmFramework.Model;
+
+namespace XrmFramework;
+
+/// <summary>
+/// The basic class used to populate a <typeparamref name="TSettings"/> object from the CRM.
+/// </summary>
+/// <typeparam name="TSettings"></typeparam>
+public class CrmSettingsFactory<TSettings> where TSettings : CrmSettings, new()
+{
+	protected IOrganizationService Service { get; }
+	private readonly Lazy<TSettings> _settings;
+
+	public TSettings Settings => _settings.Value;
+
+	/// <summary>
+	/// Constructor for the <see cref="CrmSettingsFactory{TSettings}"/> class.
+	/// </summary>
+	/// <param name="service"></param>
+	/// <param name="initSettings">If this delegate throws an <see cref="NotImplementedException"/>, uses the default <see cref="CrmSettingsFactory{TSettings}.DefaultInitSettings"/></param>
+	public CrmSettingsFactory(IOrganizationService service, InitSettings initSettings)
+	{
+		Service = service;
+		_settings = new Lazy<TSettings>(() =>
+		{
+			var propertySettings = typeof(TSettings).GetProperties()
+			                                        .Where(p => p.GetCustomAttribute<SettingNameAttribute>() != null)
+			                                        .Select(p => new {Name = p.GetCustomAttribute<SettingNameAttribute>().Name, Property = p})
+			                                        .ToList();
+
+			var returnSettings = new TSettings();
+
+			IEnumerable<(string settingName, object settingValue)> settingsValues;
+			
+			var splitPropertySettings = propertySettings.Select(p => (p.Name, p.Property.PropertyType)).ToList();
+			
+			try
+			{
+				settingsValues = initSettings(splitPropertySettings);
+			} catch (NotImplementedException _)
+			{
+				settingsValues = DefaultInitSettings(splitPropertySettings);
+			}
+
+			foreach (var value in settingsValues)
+			{
+				var property = propertySettings.FirstOrDefault(p => p.Name == value.settingName);
+
+				property?.Property.SetValue(returnSettings, value.settingValue);
+			}
+
+			return returnSettings;
+		});
+	}
+
+	public delegate IEnumerable<(string settingName, object settingValue)> InitSettings(IEnumerable<(string settingName, Type settingType)> settingDefinitions);
+	
+	public IEnumerable<(string settingName, object settingValue)> DefaultInitSettings(IEnumerable<(string settingName, Type settingType)> settingDefinitions)
+	{
+		var settings = settingDefinitions.ToList();
+
+		var results = GetEnvironmentVariables(settings.Select(s => s.settingName).ToArray());
+
+		return settings.Join(results, p => p.settingName, p => p.SchemaName, (property, parameter) =>
+		{
+			var settingValue = GetEnvironmentVariableValue(property.settingType, parameter);
+
+			(string settingName, object settingValue) p = new(parameter.SchemaName, settingValue);
+			return p;
+		}).ToList();
+	}
+	
+	public ICollection<EnvironmentVariable> GetEnvironmentVariables(params string[] schemaNames)
+	{
+		if (schemaNames == null || schemaNames.Length == 0)
+		{
+			return new List<EnvironmentVariable>();
+		}
+
+		var queryVariable = BindingModelHelper.GetRetrieveAllQuery<EnvironmentVariable>();
+
+		queryVariable.Criteria.FilterOperator = LogicalOperator.Or;
+
+		foreach (var schemaName in schemaNames) {
+			queryVariable.Criteria.AddCondition(EnvironmentVariableDefinition.Columns.SchemaName, ConditionOperator.Equal, schemaName);
+		}
+
+		var linkValue = queryVariable.AddLink(EnvironmentVariableValueDefinition.EntityName, EnvironmentVariableDefinition.Columns.Id, EnvironmentVariableValueDefinition.Columns.EnvironmentVariableDefinitionId, JoinOperator.LeftOuter);
+		linkValue.EntityAlias = EnvironmentVariableValueDefinition.EntityName;
+		linkValue.Columns.AddColumn(EnvironmentVariableValueDefinition.Columns.Value);
+
+		return Service.RetrieveAll<EnvironmentVariable>(queryVariable);
+	}
+	
+	public object GetEnvironmentVariable(Type objectType, string schemaName)
+	{
+		var variable = GetEnvironmentVariables(schemaName).FirstOrDefault();
+
+		return GetEnvironmentVariableValue(objectType, variable);
+	}
+
+	public object GetEnvironmentVariableValue(Type objectType, EnvironmentVariable variable)
+            {
+                if (variable == null)
+                {
+                    return null;
+                }
+    
+                switch (variable.Type)
+                {
+                    case EnvironmentVariableType.String:
+                        if (objectType != typeof(string))
+                        {
+                            throw new ArgumentException($"The environment variable is of type String GetEnvironmentVariable must be called with a string Type argument");
+                        }
+    
+                        return variable.Value;
+                    case EnvironmentVariableType.Number:
+                        if (objectType != typeof(int))
+                        {
+                            throw new ArgumentException($"The environment variable is of type Integer GetEnvironmentVariable must be called with a int Type argument");
+                        }
+    
+                        return int.Parse(variable.Value);
+                    case EnvironmentVariableType.Boolean:
+                        if (objectType != typeof(bool))
+                        {
+                            throw new ArgumentException($"The environment variable is of type Boolean GetEnvironmentVariable must be called with a bool Type argument");
+                        }
+    
+                        return bool.Parse(variable.Value);
+                    case EnvironmentVariableType.Json:
+                        return JsonConvert.DeserializeObject(variable.Value, objectType);
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(variable), "The Type of the environment variable is not supported");
+                }
+            }
+}

--- a/src/XrmFramework/Service/CrmSettingsFactory.cs
+++ b/src/XrmFramework/Service/CrmSettingsFactory.cs
@@ -40,14 +40,13 @@ public class CrmSettingsFactory<TSettings> where TSettings : CrmSettings, new()
 
 			var returnSettings = new TSettings();
 
-			IEnumerable<(string settingName, object settingValue)> settingsValues;
 			
 			var splitPropertySettings = propertySettings.Select(p => (p.Name, p.Property.PropertyType)).ToList();
 			
-			try
-			{
-				settingsValues = initSettings(splitPropertySettings);
-			} catch (NotImplementedException _)
+			
+			var	settingsValues = initSettings(splitPropertySettings);
+			
+			if(!settingsValues.Any())
 			{
 				settingsValues = DefaultInitSettings(splitPropertySettings);
 			}

--- a/src/XrmFramework/Service/DefaultService.cs
+++ b/src/XrmFramework/Service/DefaultService.cs
@@ -678,87 +678,9 @@ namespace XrmFramework
             Execute<AssociateRequest, AssociateResponse>(AdminOrganizationService, request,
                 bypassCustomPluginExecution);
         }
-
-        public TVariable GetEnvironmentVariable<TVariable>(string schemaName)
-        {
-            var variableObject = GetEnvironmentVariable(typeof(TVariable), schemaName);
-
-            if (variableObject == null)
-            {
-                return default(TVariable);
-            }
-
-            return (TVariable)variableObject;
-        }
-
-        protected object GetEnvironmentVariableValue(Type objectType, EnvironmentVariable variable)
-        {
-            if (variable == null)
-            {
-                return null;
-            }
-
-            switch (variable.Type)
-            {
-                case EnvironmentVariableType.String:
-                    if (objectType != typeof(string))
-                    {
-                        throw new ArgumentException($"The environment variable is of type String GetEnvironmentVariable must be called with a string Type argument");
-                    }
-
-                    return variable.Value;
-                case EnvironmentVariableType.Number:
-                    if (objectType != typeof(int))
-                    {
-                        throw new ArgumentException($"The environment variable is of type Integer GetEnvironmentVariable must be called with a int Type argument");
-                    }
-
-                    return int.Parse(variable.Value);
-                case EnvironmentVariableType.Boolean:
-                    if (objectType != typeof(bool))
-                    {
-                        throw new ArgumentException($"The environment variable is of type Boolean GetEnvironmentVariable must be called with a bool Type argument");
-                    }
-
-                    return bool.Parse(variable.Value);
-                case EnvironmentVariableType.Json:
-                    return JsonConvert.DeserializeObject(variable.Value, objectType);
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
-
-        protected ICollection<EnvironmentVariable> GetEnvironmentVariables(params string[] schemaNames)
-        {
-            if (schemaNames == null || schemaNames.Length == 0)
-            {
-                return new List<EnvironmentVariable>();
-            }
-
-            var queryVariable = BindingModelHelper.GetRetrieveAllQuery<EnvironmentVariable>();
-
-            queryVariable.Criteria.FilterOperator = LogicalOperator.Or;
-
-            foreach (var schemaName in schemaNames) {
-                queryVariable.Criteria.AddCondition(EnvironmentVariableDefinition.Columns.SchemaName, ConditionOperator.Equal, schemaName);
-            }
-
-            var linkValue = queryVariable.AddLink(EnvironmentVariableValueDefinition.EntityName, EnvironmentVariableDefinition.Columns.Id, EnvironmentVariableValueDefinition.Columns.EnvironmentVariableDefinitionId, JoinOperator.LeftOuter);
-            linkValue.EntityAlias = EnvironmentVariableValueDefinition.EntityName;
-            linkValue.Columns.AddColumn(EnvironmentVariableValueDefinition.Columns.Value);
-
-            return AdminOrganizationService.RetrieveAll<EnvironmentVariable>(queryVariable);
-        }
-
-        protected object GetEnvironmentVariable(Type objectType, string schemaName)
-        {
-            var variable = GetEnvironmentVariables(schemaName).FirstOrDefault();
-
-            return GetEnvironmentVariableValue(objectType, variable);
-        }
-
+       
         private TResponse Execute<TRequest, TResponse>(IOrganizationService service, TRequest request,
-            bool bypassCustomPluginExecution)
+                                                       bool bypassCustomPluginExecution)
             where TRequest : OrganizationRequest
             where TResponse : OrganizationResponse
         {

--- a/src/XrmFramework/Service/DefaultServiceWithSettings.cs
+++ b/src/XrmFramework/Service/DefaultServiceWithSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace XrmFramework
 {
@@ -10,13 +11,12 @@ namespace XrmFramework
 
         /// <summary>
         /// A way to override how the <see cref="CrmSettingsFactory{TSettings}"/> will retrieve the settings values.
-        /// Leaving it not implemented will cause the <see cref="CrmSettingsFactory{TSettings}"/> to use the default implementation.
+        /// Not overriding it will cause the <see cref="CrmSettingsFactory{TSettings}"/> to use the default implementation.
         /// </summary>
         /// <param name="settingDefinitions"></param>
         /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
         protected virtual IEnumerable<(string settingName, object settingValue)> InitSettings(IEnumerable<(string settingName, Type settingType)> settingDefinitions)
-            => throw new NotImplementedException();
+            => Enumerable.Empty<(string settingName, object settingValue)>();
         
         protected DefaultServiceWithSettings(IServiceContext context) : base(context)
         {

--- a/src/XrmFramework/Service/DefaultServiceWithSettings.cs
+++ b/src/XrmFramework/Service/DefaultServiceWithSettings.cs
@@ -1,58 +1,26 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 
 namespace XrmFramework
 {
     public abstract class DefaultServiceWithSettings<T> : DefaultService where T : CrmSettings, new()
     {
-        protected T Settings => _settings.Value;
+        protected CrmSettingsFactory<T> SettingsFactory { get; }
+        protected T Settings => SettingsFactory.Settings;
 
-        private readonly Lazy<T> _settings;
-
+        /// <summary>
+        /// A way to override how the <see cref="CrmSettingsFactory{TSettings}"/> will retrieve the settings values.
+        /// Leaving it not implemented will cause the <see cref="CrmSettingsFactory{TSettings}"/> to use the default implementation.
+        /// </summary>
+        /// <param name="settingDefinitions"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
         protected virtual IEnumerable<(string settingName, object settingValue)> InitSettings(IEnumerable<(string settingName, Type settingType)> settingDefinitions)
-        {
-            var settings = settingDefinitions.ToList();
-
-            var results = GetEnvironmentVariables(settings.Select(s => s.settingName).ToArray());
-
-            return settings.Join(results, p => p.settingName, p => p.SchemaName, (property, parameter) =>
-            {
-                var settingValue = GetEnvironmentVariableValue(property.settingType, parameter);
-
-                (string settingName, object settingValue) p = new(parameter.SchemaName, settingValue);
-                return p;
-            }).ToList();
-        }
-
+            => throw new NotImplementedException();
+        
         protected DefaultServiceWithSettings(IServiceContext context) : base(context)
         {
-            _settings = new Lazy<T>(() =>
-                {
-                    var propertySettings = typeof(T).GetProperties()
-                        .Where(p => p.GetCustomAttribute<SettingNameAttribute>() != null)
-                        .Select(p => new {Name = p.GetCustomAttribute<SettingNameAttribute>().Name, Property = p})
-                        .ToList();
-
-                    var returnSettings = new T();
-
-                    var settingsValues = InitSettings(
-                        propertySettings
-                            .Select(p => (p.Name, p.Property.PropertyType)
-                            )
-                    );
-
-                    foreach (var value in settingsValues)
-                    {
-                        var property = propertySettings.FirstOrDefault(p => p.Name == value.settingName);
-
-                        property?.Property.SetValue(returnSettings, value.settingValue);
-                    }
-
-                    return returnSettings;
-                });
+            SettingsFactory = new CrmSettingsFactory<T>(context.AdminOrganizationService, InitSettings);
         }
     }
 }

--- a/src/XrmFramework/Service/IService.cs
+++ b/src/XrmFramework/Service/IService.cs
@@ -86,9 +86,7 @@ namespace XrmFramework
         void AssociateRecords(EntityReference objectRef, Microsoft.Xrm.Sdk.Relationship relationName, params EntityReference[] entityReferences);
 
         void AssociateRecords(EntityReference objectRef, Microsoft.Xrm.Sdk.Relationship relationName, bool bypassCustomPluginExecution, params EntityReference[] entityReferences);
-
-        TVariable GetEnvironmentVariable<TVariable>(string schemaName);
-
+        
         void AddRoleToUserOrTeam(EntityReference userOrTeamRef, string parentRootRoleIdOrTemplateId, bool bypassCustomPluginExecution = false);
     }
 }

--- a/src/XrmFramework/Utils/DefaultLoggerWithSettings.cs
+++ b/src/XrmFramework/Utils/DefaultLoggerWithSettings.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+
+namespace XrmFramework
+{
+	public abstract class DefaultLoggerWithSettings<TSettings> : DefaultLogHelper where TSettings : CrmSettings, new()
+	{
+		protected CrmSettingsFactory<TSettings> SettingsFactory { get; }
+		protected TSettings Settings => SettingsFactory.Settings;
+
+		/// <summary>
+		/// A way to override how the <see cref="CrmSettingsFactory{TSettings}"/> will retrieve the settings values.
+		/// Leaving it not implemented will cause the <see cref="CrmSettingsFactory{TSettings}"/> to use the default implementation.
+		/// </summary>
+		/// <param name="settingDefinitions"></param>
+		/// <returns></returns>
+		/// <exception cref="NotImplementedException"></exception>
+
+		protected virtual IEnumerable<(string settingName, object settingValue)> InitSettings(IEnumerable<(string settingName, Type settingType)> settingDefinitions)
+			=> throw new NotImplementedException();
+
+		protected DefaultLoggerWithSettings(IOrganizationService service, ILoggerContext context, LogMethod logMethod) : base(service, context, logMethod)
+		{
+			SettingsFactory = new CrmSettingsFactory<TSettings>(service, InitSettings);
+		}
+	}
+}

--- a/src/XrmFramework/Utils/DefaultLoggerWithSettings.cs
+++ b/src/XrmFramework/Utils/DefaultLoggerWithSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Xrm.Sdk;
 
 namespace XrmFramework
@@ -11,14 +12,13 @@ namespace XrmFramework
 
 		/// <summary>
 		/// A way to override how the <see cref="CrmSettingsFactory{TSettings}"/> will retrieve the settings values.
-		/// Leaving it not implemented will cause the <see cref="CrmSettingsFactory{TSettings}"/> to use the default implementation.
+		/// Not overriding it will cause the <see cref="CrmSettingsFactory{TSettings}"/> to use the default implementation.
 		/// </summary>
 		/// <param name="settingDefinitions"></param>
 		/// <returns></returns>
-		/// <exception cref="NotImplementedException"></exception>
 
 		protected virtual IEnumerable<(string settingName, object settingValue)> InitSettings(IEnumerable<(string settingName, Type settingType)> settingDefinitions)
-			=> throw new NotImplementedException();
+			=> Enumerable.Empty<(string settingName, object settingValue)>();
 
 		protected DefaultLoggerWithSettings(IOrganizationService service, ILoggerContext context, LogMethod logMethod) : base(service, context, logMethod)
 		{


### PR DESCRIPTION
- Refactoring of the way DefaultServiceWithSettings populates its CrmSettings to allow classes other than IServices to use this feature.
- Introducing DefaultLoggerWithSettings as an example.

Note : All methods implemented in CrmSettingsFactory were left public as I think they might prove usefull.
Especially the DefaultInitSettings that can be used in any of the overrides of a Default[...]WithSettings and perhaps retrieve settings from two different entities (like environmentvariable and new_myenvironmentvariables)