### PR TITLE
feat: exposer NotificationService et ManagedIdentityService sur les c…

### DIFF
--- a/src/XrmFramework/Context/IServiceContext.cs
+++ b/src/XrmFramework/Context/IServiceContext.cs
@@ -9,7 +9,7 @@ namespace XrmFramework
     public interface IServiceContext : ILoggerContext
     {
         IOrganizationService AdminOrganizationService { get; }
-        
+
         IOrganizationService OrganizationService { get; }
 
         EntityReference BusinessUnitRef { get; }
@@ -17,6 +17,10 @@ namespace XrmFramework
         void Log(string message, params object[] paramsObject);
 
         IOrganizationService GetOrganizationService(Guid? userId);
+
+        IServiceEndpointNotificationService NotificationService { get; }
+
+        IManagedIdentityService ManagedIdentityService { get; }
 
         LogServiceMethod LogServiceMethod { get; }
     }

--- a/src/XrmFramework/Context/LocalContext.cs
+++ b/src/XrmFramework/Context/LocalContext.cs
@@ -15,10 +15,14 @@ namespace XrmFramework
     public partial class LocalContext : IContext, IServiceContext
     {
         private IServiceProvider ServiceProvider { get; }
+
         private IOrganizationService _adminService;
 
         public IServiceEndpointNotificationService NotificationService =>
             ServiceProvider.Get<IServiceEndpointNotificationService>();
+
+        public IManagedIdentityService ManagedIdentityService =>
+            ServiceProvider.Get<IManagedIdentityService>();
 
         private readonly EntityReference _businessUnitRef;
 

--- a/src/XrmFramework/Context/ServiceContextBase.cs
+++ b/src/XrmFramework/Context/ServiceContextBase.cs
@@ -11,6 +11,17 @@ namespace XrmFramework
     {
         public LogServiceMethod LogServiceMethod => Logger.LogWithMethodName;
 
+        // Services exposés uniquement par le pipeline d'exécution d'un plugin (via IServiceProvider).
+        // Un ServiceContextBase est construit hors pipeline (à partir d'un IOrganizationService) :
+        // ces services n'y sont pas disponibles.
+        public IServiceEndpointNotificationService NotificationService =>
+            throw new NotSupportedException(
+                "NotificationService n'est disponible que dans le pipeline d'exécution d'un plugin, pas dans un ServiceContextBase.");
+
+        public IManagedIdentityService ManagedIdentityService =>
+            throw new NotSupportedException(
+                "ManagedIdentityService n'est disponible que dans le pipeline d'exécution d'un plugin, pas dans un ServiceContextBase.");
+
         public ServiceContextBase(IOrganizationService service)
         {
             Logger = LoggerFactory.GetLogger(this, Console.WriteLine);


### PR DESCRIPTION
…ontextes de service

Ajoute IServiceEndpointNotificationService et IManagedIdentityService à IServiceContext.
- LocalContext : résolus via l'IServiceProvider du pipeline plugin.
- ServiceContextBase : NotSupportedException (construit hors pipeline, sans IServiceProvider).